### PR TITLE
Fix/created at to updated at

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "streams": [
     {
       "tap_stream_id": "uptime",
-      "replication_key": "created_at",
+      "replication_key": "updated_at",
       "replication_method": "INCREMENTAL",
       "key_properties": "id",
       "schema": {
@@ -55,7 +55,7 @@
           "metadata": {
             "table-key-properties": "id",
             "forced-replication-method": "INCREMENTAL",
-            "valid-replication-keys": ["created_at"],
+            "valid-replication-keys": ["updated_at"],
             "inclusion": "available",
             "selected": "True"
           }
@@ -118,7 +118,7 @@
     },
     {
       "tap_stream_id": "components",
-      "replication_key": "created_at",
+      "replication_key": "updated_at",
       "replication_method": "INCREMENTAL",
       "key_properties": "id",
       "schema": {
@@ -179,7 +179,7 @@
           "metadata": {
             "table-key-properties": "id",
             "forced-replication-method": "INCREMENTAL",
-            "valid-replication-keys": ["created_at"],
+            "valid-replication-keys": ["updated_at"],
             "inclusion": "available"
           }
         },
@@ -271,7 +271,7 @@
     },
     {
       "tap_stream_id": "incidents",
-      "replication_key": "created_at",
+      "replication_key": "updated_at",
       "replication_method": "INCREMENTAL",
       "key_properties": "id",
       "schema": {
@@ -387,7 +387,7 @@
           "metadata": {
             "table-key-properties": "id",
             "forced-replication-method": "INCREMENTAL",
-            "valid-replication-keys": ["created_at"],
+            "valid-replication-keys": ["updated_at"],
             "inclusion": "available"
           }
         },
@@ -431,7 +431,7 @@
     },
     {
       "tap_stream_id": "pages",
-      "replication_key": "created_at",
+      "replication_key": "updated_at",
       "replication_method": "FULL_TABLE",
       "key_properties": "id",
       "schema": {
@@ -584,7 +584,7 @@
           "metadata": {
             "table-key-properties": "id",
             "forced-replication-method": "FULL_TABLE",
-            "valid-replication-keys": ["created_at"],
+            "valid-replication-keys": ["udpated_at"],
             "inclusion": "available"
           }
         },

--- a/tap_statuspage/streams.py
+++ b/tap_statuspage/streams.py
@@ -151,8 +151,8 @@ class PagesStream(StatuspageStream):
     tap_stream_id: ClassVar[str] = 'pages'
     stream: ClassVar[str] = 'pages'
     key_properties: ClassVar[str] = 'id'
-    replication_key: ClassVar[str] = 'created_at'
-    valid_replication_keys: ClassVar[List[str]] = ['created_at']
+    replication_key: ClassVar[str] = 'updated_at'
+    valid_replication_keys: ClassVar[List[str]] = ['udpated_at']
     replication_method: ClassVar[str] = 'FULL_TABLE'
     valid_params: ClassVar[List[str]] = []
     required_params: ClassVar[List[str]] = []
@@ -176,8 +176,8 @@ class IncidentsStream(StatuspageStream):
     tap_stream_id: ClassVar[str] = 'incidents'
     stream: ClassVar[str] = 'incidents'
     key_properties: ClassVar[str] = 'id'
-    replication_key: ClassVar[str] = 'created_at'
-    valid_replication_keys: ClassVar[List[str]] = ['created_at']
+    replication_key: ClassVar[str] = 'udpated_at'
+    valid_replication_keys: ClassVar[List[str]] = ['updated_at']
     replication_method: ClassVar[str] = 'INCREMENTAL'
     valid_params: ClassVar[List[str]] = ['q', 'limit', 'page']
     required_params: ClassVar[List[str]] = []
@@ -225,8 +225,8 @@ class ComponentsStream(StatuspageStream):
     tap_stream_id: ClassVar[str] = 'components'
     stream: ClassVar[str] = 'components'
     key_properties: ClassVar[str] = 'id'
-    replication_key: ClassVar[str] = 'created_at'
-    valid_replication_keys: ClassVar[List[str]] = ['created_at']
+    replication_key: ClassVar[str] = 'updated_at'
+    valid_replication_keys: ClassVar[List[str]] = ['updated_at']
     replication_method: ClassVar[str] = 'INCREMENTAL'
     valid_params: ClassVar[List[str]] = ['page', 'per_page']
     required_params: ClassVar[List[str]] = []
@@ -274,8 +274,8 @@ class UptimeStream(StatuspageStream):
     tap_stream_id: ClassVar[str] = 'uptime'
     stream: ClassVar[str] = 'uptime'
     key_properties: ClassVar[str] = 'id'
-    replication_key: ClassVar[str] = 'created_at'
-    valid_replication_keys: ClassVar[List[str]] = ['created_at']
+    replication_key: ClassVar[str] = 'updated_at'
+    valid_replication_keys: ClassVar[List[str]] = ['updated_at']
     replication_method: ClassVar[str] = 'INCREMENTAL'
     valid_params: ClassVar[List[str]] = ['start', 'end']
     required_params: ClassVar[List[str]] = ['start', 'end']

--- a/tests/data/test.config.json
+++ b/tests/data/test.config.json
@@ -4,7 +4,7 @@
   "since": "2019-01-01T00:00:00Z",
   "streams": {
     "incidents": {
-      "sort_by": "created_at:asc"
+      "sort_by": "updated_at:asc"
     }
   }
 }


### PR DESCRIPTION
# Motivation

Seeing a bunch of truncated data at the moment where we get snippets of the correct values. Pretty sure that's because the `created_at` values stay stale, while the various streams have updates represented by the `updated_at` value