### PR TITLE
Add Gitleaks allowlist file

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+
+[[ rules ]]
+    id = "generic-api-key"
+    [ rules.allowlist ]
+        commits = [
+            "832de51e8f8928ecb60a8f80350511c75defce44",
+            
+        ]


### PR DESCRIPTION
## Motivation / Implements

This PR adds `.gitleaks.toml` to the root of this repo. This file is consumed by the secret-scanning tool that Apollo's SecOps team uses to check for secrets in our source.

This file is being added with the required configuration to tell the scanning tool to ignore values that SecOps has confirmed as false positives.

I will follow up on this PR, but if a maintainer on this repo wants to get ahead of me, this PR is safe to merge at your convenience. Let us know in #security if you have any issues or questions!

Thank you!
